### PR TITLE
Incorrect namespaced property in docs

### DIFF
--- a/docs/pages/api/store.md
+++ b/docs/pages/api/store.md
@@ -24,7 +24,6 @@ import Api from 'services/Api'
 import { make } from 'vuex-pathify'
 
 const state = {
-  // namespaced: true, // add this if in module
   items: [],
   status: '',
   filters: {
@@ -62,6 +61,7 @@ const getters = {
 }
 
 export default {
+  // namespaced: true, // add this if in module
   state,
   mutations,
   actions,


### PR DESCRIPTION
In the Store Helpers docs, the `namespaced` property should be part of the root object and not the state object.