### PR TITLE
Return the call to vuex.store.dispatch

### DIFF
--- a/src/helpers/vuex.js
+++ b/src/helpers/vuex.js
@@ -24,7 +24,7 @@ export function commit(...args) {
 }
 
 export function dispatch(...args) {
-  vuex.store.dispatch(...args)
+  return vuex.store.dispatch(...args)
 }
 
 export default vuex


### PR DESCRIPTION
Vuex actions are typically asynchronous and, therefore, benefit from being able to return promises. The dispatch helper needs to return the dispatch call so that any promise that is returned gets returned to the caller. The commit helper should probably have it's call result returned as well, but the use case is atypical.