### PR TITLE
Can't access the state with dollar sign in the name.

### DIFF
--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -49,7 +49,7 @@ export function getKeys (value) {
       : typeof value === 'object'
         ? Object.keys(value)
         : typeof value === 'string'
-          ? value.match(/\w+/g) || []
+          ? value.match(/[$\w]+/g) || []
           : []
 }
 


### PR DESCRIPTION
I've found that when you try to use get() or sync() for a state like that:

`{ status: { $in: [] }`

It generates the path as ["status", "in"] without dollar sign. 