### PR TITLE
Added missing return to callOne()

### DIFF
--- a/src/helpers/component.js
+++ b/src/helpers/component.js
@@ -149,6 +149,6 @@ export function setOne (path) {
  */
 export function callOne (path) {
   return function (value) {
-    this.$store.dispatch(path, value)
+    return this.$store.dispatch(path, value)
   }
 }


### PR DESCRIPTION
The call() helper isn't returning the dispatch result, I've fixed that.  There is a related PR (https://github.com/davestewart/vuex-pathify/pull/37) but doesn't fix the problem