### PR TITLE
Use typeof instead of instanceof to check for functions (fix for [vuex] unknown local mutation type)

### DIFF
--- a/src/helpers/accessors.js
+++ b/src/helpers/accessors.js
@@ -29,7 +29,7 @@ export default function (store) {
     const getter = makeGetter(store, path)
     if (typeof getter !== 'undefined') {
       const value = getter()
-      return value instanceof Function
+      return typeof value === 'function'
         ? value(...args)
         : value
     }

--- a/src/helpers/store.js
+++ b/src/helpers/store.js
@@ -9,7 +9,7 @@ import Payload from '../classes/Payload'
  * @returns {Array}
  */
 function getStateKeys (state) {
-  return getKeys(state instanceof Function ? state() : state)
+  return getKeys(typeof state === 'function' ? state() : state)
 }
 
 /**

--- a/src/plugin/debug.js
+++ b/src/plugin/debug.js
@@ -9,7 +9,7 @@ export default function debug () {
   console.log(`
   [Vuex Pathify] Options:
 
-  Mapping (${options.mapping instanceof Function ? 'custom' : options.mapping})
+  Mapping (${typeof options.mapping === 'function' ? 'custom' : options.mapping})
 -------------------------------
   path       : value
   state      : ${resolve('state')}

--- a/src/services/resolver.js
+++ b/src/services/resolver.js
@@ -72,7 +72,7 @@ export function resolveName (type, name) {
 
   // unconfigured resolver! (runs once)
   if (!fn) {
-    if (options.mapping instanceof Function) {
+    if (typeof options.mapping === 'function') {
       fn = options.mapping
     }
     else {


### PR DESCRIPTION
Hello,

After upgrading to Nuxt 2.4, I noticed vue-pathify had stopped working correctly when using state functions with server-side rendering, like this one:
```
export const state = () => ({
  user: null
});
export const mutations = make.mutations(state);
// It generates an empty array server-side and then "[vuex] unknown local mutation type"
```
I investigated and I discovered that the error was coming from the function check inside Vue-pathify: the "state instanceof Function" doesn't return true anymore while it is clearly a function.

Using instanceof to check for functions is not a good pratice because the "Function" type doesn't cover all the JS functions:
- see here: https://stackoverflow.com/questions/899574/what-is-the-difference-between-typeof-and-instanceof-and-when-should-one-be-used
- also you won't find any "instanceof Function" check on Vue.js, they are all "typeof var === 'function'".

I haven't completely investigated why in the case of SSR and with the new versions of the libs that Nuxt 2.4 use, the functions that are exported by a component do not have the "Function" type anymore, anyway this should be fixed to avoid future problems.

Thanks!