### PR TITLE
add vue-class-component to dependencies. Fixes #50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-pathify",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5193,10 +5193,9 @@
       "dev": true
     },
     "vue-class-component": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-6.3.2.tgz",
-      "integrity": "sha512-cH208IoM+jgZyEf/g7mnFyofwPDJTM/QvBNhYMjqGB8fCsRyTf68rH2ISw/G20tJv+5mIThQ3upKwoL4jLTr1A==",
-      "dev": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.0.2.tgz",
+      "integrity": "sha512-8xw/wkZI2tgHcwvkSRC1ax7GeP1CG27wKhedvOAdjdASm05VU4RijGsCYti6s6CzBioBL5BQUmntQQTCsp1wnQ=="
     },
     "vuex": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "url": "https://github.com/davestewart/vuex-pathify/issues"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "vue-class-component": "^7.0.2"
   },
   "devDependencies": {
     "install": "^0.12.2",
@@ -45,7 +46,6 @@
     "rollup-plugin-uglify": "^3.0.0",
     "typescript": "^3.2.2",
     "vue": "^2.5.20",
-    "vue-class-component": "^6.3.2",
     "vuex": "^3.0.1"
   },
   "peerDependencies": {

--- a/src/helpers/decorators.js
+++ b/src/helpers/decorators.js
@@ -15,17 +15,7 @@
 
 import { get, sync, call } from "./component"
 
-let createDecorator
-
-// Developers not useing `vue-class-component` do not need decorators.
-// Require is put in try-catch block to avoid installation of `vue-class-component` for those who do not need.
-// Developers using class components already have to include `vue-class-component`. So this require will use it.
-try {
-  createDecorator = require('vue-class-component').createDecorator
-} catch(e) {
-  // Decorators are not available, so there is no need for decorators.
-  createDecorator = () => { throw new Error("'vue-class-component' is required for decorators. Use 'npm -i vue-class-component'") }
-}
+let createDecorator = require('vue-class-component').createDecorator;
 
 /**
  * Decortaor for `get` component helper.


### PR DESCRIPTION
Added `vue-class-component` to dependencies to support decorators. Added size is ignorable, because `vue-class-component` has around 200 LOC and does not have any other dependencies.