### PR TITLE
check that module already exist or not in store.

### DIFF
--- a/src/helpers/modules.js
+++ b/src/helpers/modules.js
@@ -8,9 +8,11 @@
  * @returns {object}                    The mixin
  */
 export function registerModule(path, module, callback, options) {
+  const hasModule = (store, path) => !!(store.state && store.state[path])
+  
   return {
     beforeCreate () {
-      this.$store.registerModule(path, module, options)
+      !hasModule(this.$store, path) && this.$store.registerModule(path, module, options)
       const members = callback()
       this.$options.computed = Object.assign(this.$options.computed || {}, members.computed || {})
       this.$options.methods = Object.assign(this.$options.methods || {}, members.methods || {})


### PR DESCRIPTION
to fix "[vuex] duplicate getter key" error.