### PR TITLE
broken links fixed

### DIFF
--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -89,7 +89,7 @@ In practical terms, Pathify results in:
 To get started:
 
 - visit the [Installation](/setup/install.md) page to install and use Pathify now
-- read the [API](/api/index.md) section for a deep dive into Pathify's features
+- read the [API](/api/paths.md) section for a deep dive into Pathify's features
 
 To see Pathify in action:
 

--- a/docs/pages/setup/install.md
+++ b/docs/pages/setup/install.md
@@ -54,7 +54,7 @@ export default new Vuex.Store({
 
 To get going immediately after installing, check out:
 
-- [API reference](/api/index.md)
+- [API reference](/api/paths.md)
 - [Demos](/intro/demos.md)   
 
 


### PR DESCRIPTION
## What Changed?
- `api/index`routes weren't available and links at home and install pages were redirecting into 404 page. It'll redirect to `api/paths` route now.