### PR TITLE
fixes broken umd bundles

### DIFF
--- a/src/helpers/decorators.js
+++ b/src/helpers/decorators.js
@@ -14,8 +14,7 @@
  */
 
 import { call, get, sync } from './component'
-
-const createDecorator = require('vue-class-component').createDecorator
+import { createDecorator } from 'vue-class-component'
 
 /**
  * Decorator for `get` component helper.


### PR DESCRIPTION
Having a dynamic `require`-call will result in `vue-class-components` not being added to the bundle, and the `require`-call stays unchanged, breaking consuming UMD bundles.

Fixes #116