### PR TITLE
Update isIndex logic to omit zero-leading integer strings

### DIFF
--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -84,7 +84,7 @@ export function getValue (obj, path) {
 export function setValue (obj, path, value, create = false) {
   const keys = getKeys(path)
   return keys.reduce((obj, key, index)  => {
-    const isIndex = /^\d+$/.test(key)
+    const isIndex = /^0$|^[1-9]\d*$/.test(key)
     if (isIndex) {
       key = parseInt(key)
     }


### PR DESCRIPTION
This is my fairly rudimentary attempt to address #122

Omit zero-leading numeric strings from being considered indexes and therefore being parsed to integers.

Caveat that this is selfishly addressing the specific scenario occurring in my project, devoid of the wider code bases's context and ramifications it may have. Additionally, very likely a different approach/alternate solution here, if any action is warranted at all. Happily accept guidance to that end.

Thanks!