### PR TITLE
Add support of serialized Payload

### DIFF
--- a/src/helpers/store.js
+++ b/src/helpers/store.js
@@ -40,9 +40,14 @@ export function makeMutations (state) {
     .reduce(function (obj, key) {
       const mutation = resolveName('mutations', key)
       obj[mutation] = function (state, value) {
-        state[key] = value instanceof Payload
-          ? value.update(state[key])
-          : value
+          if (value instanceof Payload) {
+              state[key] = value.update(state[key]);
+          } else if (typeof value === "object" && "expr" in value && "path" in value && "value" in value) {
+              const payload = new Payload (value.expr, value.path, value.value);
+              state[key] = payload.update(state[key]);
+          } else {
+              state[key] = value;
+          }
       }
       return obj
     }, {})

--- a/tests/store-accessors.test.js
+++ b/tests/store-accessors.test.js
@@ -131,3 +131,20 @@ describe('special functionality', function () {
     })
   })
 })
+
+describe('serialized Payload', () => {
+  it('serialized Payload should be interpreted', function () {
+    const state = { name: { firstName: 'John', lastName: 'Doe' }, age: 28 }
+    const mutations = make.mutations(state)
+    const store = makeStore({
+      modules: {
+        people: { namespaced: true, state, mutations }
+      }
+    })
+
+    store.commit('people/name', { expr: 'people/name@firstname', value: 'Jane', path: 'firstname' })
+
+    expect(store.get('people/name@firstname')).toEqual('Jane')
+    expect(store.get('people/age')).toEqual(28)
+  })
+})


### PR DESCRIPTION
The support of serialized Payload allows to use other vuex plugins
like persisted and tab-sync to work with vuex-pathify.

For example, when we made a change on the store on a tab A, and a plugin sync with a tab B, the tab B receive Payload in serialized (JSON) way.
This PR is intented to support this kind of cases, when a serialization is made, and cannot be avoided.