### PR TITLE
Use Payload class with any type of data mutation

### DIFF
--- a/src/classes/Payload.js
+++ b/src/classes/Payload.js
@@ -22,6 +22,11 @@ export default class Payload {
       return target
     }
 
+    if (!this.path) {
+      target = this.value;
+      return target;
+    }
+
     const success = setValue(target, this.path, this.value, options.deep > 1)
 
     // unable to set sub-property

--- a/src/services/store.js
+++ b/src/services/store.js
@@ -20,9 +20,7 @@ export function makeSetter (store, path) {
   const action = resolver.get('actions')
   if (action.exists) {
     return function (value) {
-      const payload = action.objPath
-        ? new Payload(path, action.objPath, value)
-        : value
+      const payload = new Payload(path, action.objPath, value)
       return store.dispatch(action.trgPath, payload)
     }
   }
@@ -35,9 +33,7 @@ export function makeSetter (store, path) {
         const interpolated = interpolate(path, this)
         mutation = resolve(store, interpolated).get('mutations')
       }
-      const payload = mutation.objPath
-        ? new Payload(path, mutation.objPath, value)
-        : value
+      const payload = new Payload(path, mutation.objPath, value)
       return store.commit(mutation.trgPath, payload)
     }
   }

--- a/tests/store-accessors.test.js
+++ b/tests/store-accessors.test.js
@@ -92,6 +92,23 @@ describe('module state', function () {
 
     expect(store.state.people.name).toEqual('Jill')
   })
+
+  it('should set state with Payload class', () => {
+    const state = { name: 'Jack', age: 28 }
+    const mutations = make.mutations(state)
+    const store = makeStore({
+      modules: {
+        people: { namespaced: true, state, mutations }
+      }
+    })
+    store.subscribe((mutation) => {
+      expect(mutation.payload.constructor.name).toEqual("Payload")
+    })
+
+    store.set('people/name', 'Jill')
+
+    expect(store.state.people.name).toEqual('Jill')
+  })
 })
 
 describe('special functionality', function () {


### PR DESCRIPTION
This PR attempt to solve the special case raised in #138.

With the use of `Payload` class in any cases of data / path processed trough `vuex-pathify`, it become trivial to know (when we make a `store.subscribe`) if a mutation has been created by pathify.

To sum up:

- if it's a POJO, it would have been deserialized
- if it's a Payload, it would have been created internally by Pathify

A deserialization can occur when we sync the store across tabs (with `vuex-shared-mutations` for example).

Fix #138 